### PR TITLE
Lazy GNN operator initialization

### DIFF
--- a/test/nn/dense/test_dense_gcn_conv.py
+++ b/test/nn/dense/test_dense_gcn_conv.py
@@ -9,7 +9,7 @@ def test_dense_gcn_conv():
     assert dense_conv.__repr__() == 'DenseGCNConv(16, 16)'
 
     # Ensure same weights and bias.
-    dense_conv.linear.weight = sparse_conv.linear.weight
+    dense_conv.lin.weight = sparse_conv.lin.weight
     dense_conv.bias = sparse_conv.bias
 
     x = torch.randn((5, channels))

--- a/test/nn/dense/test_dense_gcn_conv.py
+++ b/test/nn/dense/test_dense_gcn_conv.py
@@ -9,7 +9,7 @@ def test_dense_gcn_conv():
     assert dense_conv.__repr__() == 'DenseGCNConv(16, 16)'
 
     # Ensure same weights and bias.
-    dense_conv.weight = sparse_conv.weight
+    dense_conv.linear.weight = sparse_conv.linear.weight
     dense_conv.bias = sparse_conv.bias
 
     x = torch.randn((5, channels))

--- a/torch_geometric/nn/conv/eg_conv.py
+++ b/torch_geometric/nn/conv/eg_conv.py
@@ -42,7 +42,8 @@ class EGConv(MessagePassing):
         examples/egc.py>`_.
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample, or -1 to derive the
+            shape from the first input(s) to the forward method.
         out_channels (int): Size of each output sample.
         aggregators (List[str], optional): Aggregators to be used.
             Supported aggregators are :obj:`"sum"`, :obj:`"mean"`,

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -6,12 +6,11 @@ from torch import Tensor
 from torch.nn import Parameter
 from torch_scatter import scatter_add
 from torch_sparse import SparseTensor, matmul, fill_diag, sum, mul
+from torch_geometric.nn.inits import zeros
+from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.utils import add_remaining_self_loops
 from torch_geometric.utils.num_nodes import maybe_num_nodes
-
-from ..dense import Linear
-from ..inits import zeros
 
 
 @torch.jit._overload
@@ -92,8 +91,8 @@ class GCNConv(MessagePassing):
     node :obj:`i` (default: :obj:`1.0`)
 
     Args:
-        in_channels (int): Size of each input sample, or -1 to derive the
-            shape from the first input(s) to the forward method.
+        in_channels (int): Size of each input sample, or :obj:`-1` to derive
+            the size from the first input(s) to the forward method.
         out_channels (int): Size of each output sample.
         improved (bool, optional): If set to :obj:`True`, the layer computes
             :math:`\mathbf{\hat{A}}` as :math:`\mathbf{A} + 2\mathbf{I}`.
@@ -136,8 +135,8 @@ class GCNConv(MessagePassing):
         self._cached_edge_index = None
         self._cached_adj_t = None
 
-        self.linear = Linear(in_channels, out_channels,
-                             bias=False, weight_initializer="glorot")
+        self.lin = Linear(in_channels, out_channels, bias=False,
+                          weight_initializer='glorot')
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -147,7 +146,7 @@ class GCNConv(MessagePassing):
         self.reset_parameters()
 
     def reset_parameters(self):
-        self.linear.reset_parameters()
+        self.lin.reset_parameters()
         zeros(self.bias)
         self._cached_edge_index = None
         self._cached_adj_t = None
@@ -179,7 +178,7 @@ class GCNConv(MessagePassing):
                 else:
                     edge_index = cache
 
-        x = self.linear(x)
+        x = self.lin(x)
 
         # propagate_type: (x: Tensor, edge_weight: OptTensor)
         out = self.propagate(edge_index, x=x, edge_weight=edge_weight,

--- a/torch_geometric/nn/conv/gcn_conv.py
+++ b/torch_geometric/nn/conv/gcn_conv.py
@@ -92,7 +92,8 @@ class GCNConv(MessagePassing):
     node :obj:`i` (default: :obj:`1.0`)
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample, or -1 to derive the
+            shape from the first input(s) to the forward method.
         out_channels (int): Size of each output sample.
         improved (bool, optional): If set to :obj:`True`, the layer computes
             :math:`\mathbf{\hat{A}}` as :math:`\mathbf{A} + 2\mathbf{I}`.

--- a/torch_geometric/nn/conv/hypergraph_conv.py
+++ b/torch_geometric/nn/conv/hypergraph_conv.py
@@ -6,10 +6,9 @@ from torch.nn import Parameter
 import torch.nn.functional as F
 from torch_scatter import scatter_add
 from torch_geometric.utils import softmax
+from torch_geometric.nn.inits import glorot, zeros
+from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.nn.conv import MessagePassing
-
-from ..dense import Linear
-from ..inits import glorot, zeros
 
 
 class HypergraphConv(MessagePassing):
@@ -40,8 +39,8 @@ class HypergraphConv(MessagePassing):
         ])
 
     Args:
-        in_channels (int): Size of each input sample, or -1 to derive the
-            shape from the first input(s) to the forward method.
+        in_channels (int): Size of each input sample, or :obj:`-1` to derive
+            the size from the first input(s) to the forward method.
         out_channels (int): Size of each output sample.
         use_attention (bool, optional): If set to :obj:`True`, attention
             will be added to this layer. (default: :obj:`False`)
@@ -75,14 +74,14 @@ class HypergraphConv(MessagePassing):
             self.concat = concat
             self.negative_slope = negative_slope
             self.dropout = dropout
-            self.linear = Linear(in_channels, heads * out_channels,
-                                 bias=False, weight_initializer="glorot")
+            self.lin = Linear(in_channels, heads * out_channels, bias=False,
+                              weight_initializer='glorot')
             self.att = Parameter(torch.Tensor(1, heads, 2 * out_channels))
         else:
             self.heads = 1
             self.concat = True
-            self.linear = Linear(in_channels, out_channels,
-                                 bias=False, weight_initializer="glorot")
+            self.lin = Linear(in_channels, out_channels, bias=False,
+                              weight_initializer='glorot')
 
         if bias and concat:
             self.bias = Parameter(torch.Tensor(heads * out_channels))
@@ -94,7 +93,7 @@ class HypergraphConv(MessagePassing):
         self.reset_parameters()
 
     def reset_parameters(self):
-        self.linear.reset_parameters()
+        self.lin.reset_parameters()
         if self.use_attention:
             glorot(self.att)
         zeros(self.bias)
@@ -124,13 +123,13 @@ class HypergraphConv(MessagePassing):
         if hyperedge_weight is None:
             hyperedge_weight = x.new_ones(num_edges)
 
-        x = self.linear(x)
+        x = self.lin(x)
 
         alpha = None
         if self.use_attention:
             assert hyperedge_attr is not None
             x = x.view(-1, self.heads, self.out_channels)
-            hyperedge_attr = self.linear(hyperedge_attr)
+            hyperedge_attr = self.lin(hyperedge_attr)
             hyperedge_attr = hyperedge_attr.view(-1, self.heads,
                                                  self.out_channels)
             x_i = x[hyperedge_index[0]]

--- a/torch_geometric/nn/conv/hypergraph_conv.py
+++ b/torch_geometric/nn/conv/hypergraph_conv.py
@@ -40,7 +40,8 @@ class HypergraphConv(MessagePassing):
         ])
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample, or -1 to derive the
+            shape from the first input(s) to the forward method.
         out_channels (int): Size of each output sample.
         use_attention (bool, optional): If set to :obj:`True`, attention
             will be added to this layer. (default: :obj:`False`)

--- a/torch_geometric/nn/dense/__init__.py
+++ b/torch_geometric/nn/dense/__init__.py
@@ -1,19 +1,19 @@
+from .linear import Linear
 from .dense_sage_conv import DenseSAGEConv
 from .dense_gcn_conv import DenseGCNConv
 from .dense_graph_conv import DenseGraphConv
 from .dense_gin_conv import DenseGINConv
 from .diff_pool import dense_diff_pool
-from .linear import Linear
 from .mincut_pool import dense_mincut_pool
 
 __all__ = [
+    'Linear',
     'DenseGCNConv',
     'DenseGINConv',
     'DenseGraphConv',
     'DenseSAGEConv',
     'dense_diff_pool',
     'dense_mincut_pool',
-    'Linear',
 ]
 
 conv_classes = __all__[:4]

--- a/torch_geometric/nn/dense/dense_gcn_conv.py
+++ b/torch_geometric/nn/dense/dense_gcn_conv.py
@@ -1,8 +1,8 @@
 import torch
 from torch.nn import Parameter
 
-from .linear import Linear
-from ..inits import zeros
+from torch_geometric.nn.inits import zeros
+from torch_geometric.nn.dense.linear import Linear
 
 
 class DenseGCNConv(torch.nn.Module):
@@ -15,8 +15,8 @@ class DenseGCNConv(torch.nn.Module):
         self.out_channels = out_channels
         self.improved = improved
 
-        self.linear = Linear(in_channels, out_channels,
-                             bias=False, weight_initializer="glorot")
+        self.lin = Linear(in_channels, out_channels, bias=False,
+                          weight_initializer='glorot')
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -26,7 +26,7 @@ class DenseGCNConv(torch.nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        self.linear.reset_parameters()
+        self.lin.reset_parameters()
         zeros(self.bias)
 
     def forward(self, x, adj, mask=None, add_loop=True):
@@ -56,7 +56,7 @@ class DenseGCNConv(torch.nn.Module):
             idx = torch.arange(N, dtype=torch.long, device=adj.device)
             adj[:, idx, idx] = 1 if not self.improved else 2
 
-        out = self.linear(x)
+        out = self.lin(x)
         deg_inv_sqrt = adj.sum(dim=-1).clamp(min=1).pow(-0.5)
 
         adj = deg_inv_sqrt.unsqueeze(-1) * adj * deg_inv_sqrt.unsqueeze(-2)

--- a/torch_geometric/nn/dense/dense_gcn_conv.py
+++ b/torch_geometric/nn/dense/dense_gcn_conv.py
@@ -1,7 +1,8 @@
 import torch
 from torch.nn import Parameter
 
-from ..inits import glorot, zeros
+from .linear import Linear
+from ..inits import zeros
 
 
 class DenseGCNConv(torch.nn.Module):
@@ -14,7 +15,8 @@ class DenseGCNConv(torch.nn.Module):
         self.out_channels = out_channels
         self.improved = improved
 
-        self.weight = Parameter(torch.Tensor(self.in_channels, out_channels))
+        self.linear = Linear(in_channels, out_channels,
+                             bias=False, weight_initializer="glorot")
 
         if bias:
             self.bias = Parameter(torch.Tensor(out_channels))
@@ -24,7 +26,7 @@ class DenseGCNConv(torch.nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self):
-        glorot(self.weight)
+        self.linear.reset_parameters()
         zeros(self.bias)
 
     def forward(self, x, adj, mask=None, add_loop=True):
@@ -54,7 +56,7 @@ class DenseGCNConv(torch.nn.Module):
             idx = torch.arange(N, dtype=torch.long, device=adj.device)
             adj[:, idx, idx] = 1 if not self.improved else 2
 
-        out = torch.matmul(x, self.weight)
+        out = self.linear(x)
         deg_inv_sqrt = adj.sum(dim=-1).clamp(min=1).pow(-0.5)
 
         adj = deg_inv_sqrt.unsqueeze(-1) * adj * deg_inv_sqrt.unsqueeze(-2)


### PR DESCRIPTION
Instead of explicitly setting the input feature dimensionality, we can initialize parameters in a lazy fashion (inspired by the `LazyLinear` module of PyTorch). This is especially useful in heterogeneous graphs, where node types may come with different input feature dimensionality:
```python
conv = SAGEConv(-1, 128)  # Should handle message passing in bipartite graphs as well
```