### PR TITLE
Lazy GNN initialization for almost all GNN operators

### DIFF
--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -21,7 +21,8 @@ class ClusterGCNConv(MessagePassing):
     + \mathbf{I})`.
 
     Args:
-        in_channels (int or tuple): Size of each input sample.
+        in_channels (int or tuple): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         diag_lambda: (float, optional): Diagonal enhancement value
             :math:`\lambda`. (default: :obj:`0.`)

--- a/torch_geometric/nn/conv/cluster_gcn_conv.py
+++ b/torch_geometric/nn/conv/cluster_gcn_conv.py
@@ -1,13 +1,10 @@
 from torch_geometric.typing import Adj, Size, OptTensor
 
-import torch
 from torch import Tensor
-from torch.nn import Parameter
 from torch_sparse import SparseTensor, matmul, set_diag, sum
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.utils import remove_self_loops, add_self_loops, degree
-
-from ..inits import glorot, zeros
 
 
 class ClusterGCNConv(MessagePassing):
@@ -46,20 +43,16 @@ class ClusterGCNConv(MessagePassing):
         self.diag_lambda = diag_lambda
         self.add_self_loops = add_self_loops
 
-        self.weight = Parameter(torch.Tensor(in_channels, out_channels))
-        self.root_weight = Parameter(torch.Tensor(in_channels, out_channels))
-
-        if bias:
-            self.bias = Parameter(torch.Tensor(out_channels))
-        else:
-            self.register_parameter('bias', None)
+        self.lin_out = Linear(in_channels, out_channels, bias=bias,
+                              weight_initializer='glorot')
+        self.lin_root = Linear(in_channels, out_channels, bias=False,
+                               weight_initializer='glorot')
 
         self.reset_parameters()
 
     def reset_parameters(self):
-        glorot(self.weight)
-        glorot(self.root_weight)
-        zeros(self.bias)
+        self.lin_out.reset_parameters()
+        self.lin_root.reset_parameters()
 
     def forward(self, x: Tensor, edge_index: Adj, size: Size = None) -> Tensor:
         """"""
@@ -90,10 +83,7 @@ class ClusterGCNConv(MessagePassing):
         # propagate_type: (x: Tensor, edge_weight: OptTensor)
         out = self.propagate(edge_index, x=x, edge_weight=edge_weight,
                              size=None)
-        out = out @ self.weight + x @ self.root_weight
-
-        if self.bias is not None:
-            out += self.bias
+        out = self.lin_out(out) + self.lin_root(x)
 
         return out
 

--- a/torch_geometric/nn/conv/film_conv.py
+++ b/torch_geometric/nn/conv/film_conv.py
@@ -35,7 +35,8 @@ class FiLMConv(MessagePassing):
 
     Args:
         in_channels (int or tuple): Size of each input sample. A tuple
-            corresponds to the sizes of source and target dimensionalities.
+            corresponds to the sizes of source and target dimensionalities. The
+            size can be -1 for lazy initialization.
         out_channels (int): Size of each output sample.
         num_relations (int, optional): Number of relations. (default: :obj:`1`)
         nn (torch.nn.Module, optional): The neural network :math:`g` that

--- a/torch_geometric/nn/conv/film_conv.py
+++ b/torch_geometric/nn/conv/film_conv.py
@@ -3,9 +3,10 @@ from typing import Union, Tuple, Optional, Callable
 from torch_geometric.typing import PairTensor, Adj, OptTensor
 
 from torch import Tensor
-from torch.nn import ModuleList, Linear, ReLU
+from torch.nn import ModuleList, ReLU
 from torch_sparse import SparseTensor, masked_select_nnz
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 
 from ..inits import reset
 

--- a/torch_geometric/nn/conv/gen_conv.py
+++ b/torch_geometric/nn/conv/gen_conv.py
@@ -59,7 +59,8 @@ class GENConv(MessagePassing):
         ogbn_proteins_deepgcn.py>`_.
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         aggr (str, optional): The aggregation scheme to use (:obj:`"softmax"`,
             :obj:`"softmax_sg"`, :obj:`"power"`, :obj:`"add"`, :obj:`"mean"`,

--- a/torch_geometric/nn/conv/gen_conv.py
+++ b/torch_geometric/nn/conv/gen_conv.py
@@ -5,11 +5,12 @@ import torch
 from torch import Tensor
 from torch.nn import Parameter
 import torch.nn.functional as F
-from torch.nn import Sequential, Linear, ReLU, Dropout
+from torch.nn import Sequential, ReLU, Dropout
 from torch.nn import BatchNorm1d, LayerNorm, InstanceNorm1d
 from torch_sparse import SparseTensor
 from torch_scatter import scatter, scatter_softmax
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.nn.norm import MessageNorm
 
 from ..inits import reset
@@ -20,7 +21,7 @@ class MLP(Sequential):
                  bias: bool = True, dropout: float = 0.):
         m = []
         for i in range(1, len(channels)):
-            m.append(Linear(channels[i - 1], channels[i], bias))
+            m.append(Linear(channels[i - 1], channels[i], bias=bias))
 
             if i < len(channels) - 1:
                 if norm and norm == 'batch':

--- a/torch_geometric/nn/conv/le_conv.py
+++ b/torch_geometric/nn/conv/le_conv.py
@@ -1,5 +1,5 @@
-from torch.nn import Linear
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 
 
 class LEConv(MessagePassing):

--- a/torch_geometric/nn/conv/le_conv.py
+++ b/torch_geometric/nn/conv/le_conv.py
@@ -18,7 +18,8 @@ class LEConv(MessagePassing):
     target node :obj:`i` (default: :obj:`1`)
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         bias (bool, optional): If set to :obj:`False`, the layer will
             not learn an additive bias. (default: :obj:`True`).

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -7,7 +7,8 @@ from torch_sparse import SparseTensor, matmul
 
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.utils import degree
-from torch.nn import Linear, ModuleList
+from torch.nn import ModuleList
+from torch_geometric.nn.dense.linear import Linear
 
 
 class MFConv(MessagePassing):

--- a/torch_geometric/nn/conv/mf_conv.py
+++ b/torch_geometric/nn/conv/mf_conv.py
@@ -24,7 +24,8 @@ class MFConv(MessagePassing):
 
     Args:
         in_channels (int or tuple): Size of each input sample. A tuple
-            corresponds to the sizes of source and target dimensionalities.
+            corresponds to the sizes of source and target dimensionalities. The
+            size can be -1 for lazy initialization.
         out_channels (int): Size of each output sample.
         max_degree (int, optional): The maximum node degree to consider when
             updating weights (default: :obj:`10`)

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -3,10 +3,11 @@ from torch_geometric.typing import Adj
 
 import torch
 from torch import Tensor
-from torch.nn import Parameter, Linear
+from torch.nn import Parameter
 from torch_sparse import SparseTensor, matmul
 
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 
 
 class PANConv(MessagePassing):

--- a/torch_geometric/nn/conv/pan_conv.py
+++ b/torch_geometric/nn/conv/pan_conv.py
@@ -28,7 +28,8 @@ class PANConv(MessagePassing):
         \mathbf{A}^n \mathbf{Z}^{-1/2}
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         filter_size (int): The filter size :math:`L`.
         **kwargs (optional): Additional arguments of

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -4,8 +4,9 @@ from torch_geometric.typing import Adj, OptTensor
 import torch
 from torch import Tensor
 from torch_scatter import scatter
-from torch.nn import ModuleList, Sequential, Linear, ReLU
+from torch.nn import ModuleList, Sequential, ReLU
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.utils import degree
 
 from ..inits import reset

--- a/torch_geometric/nn/conv/pna_conv.py
+++ b/torch_geometric/nn/conv/pna_conv.py
@@ -48,7 +48,8 @@ class PNAConv(MessagePassing):
         examples/pna.py>`_.
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         aggregators (list of str): Set of aggregation function identifiers,
             namely :obj:`"sum"`, :obj:`"mean"`, :obj:`"min"`, :obj:`"max"`,

--- a/torch_geometric/nn/conv/res_gated_graph_conv.py
+++ b/torch_geometric/nn/conv/res_gated_graph_conv.py
@@ -3,8 +3,9 @@ from torch_geometric.typing import PairTensor, Adj
 
 from torch import Tensor
 from torch.nn import Parameter
-from torch.nn import Linear, Sigmoid
+from torch.nn import Sigmoid
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 
 from ..inits import zeros
 

--- a/torch_geometric/nn/conv/res_gated_graph_conv.py
+++ b/torch_geometric/nn/conv/res_gated_graph_conv.py
@@ -28,7 +28,8 @@ class ResGatedGraphConv(MessagePassing):
 
     Args:
         in_channels (int or tuple): Size of each input sample. A tuple
-            corresponds to the sizes of source and target dimensionalities.
+            corresponds to the sizes of source and target dimensionalities. The
+            size can be -1 for lazy initialization.
         out_channels (int): Size of each output sample.
         act (callable, optional): Gating function :math:`\sigma`.
             (default: :meth:`torch.nn.Sigmoid()`)

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -2,10 +2,10 @@ from typing import Union, Tuple
 from torch_geometric.typing import OptPairTensor, Adj, Size
 
 from torch import Tensor
-from torch.nn import Linear
 import torch.nn.functional as F
 from torch_sparse import SparseTensor, matmul
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 
 
 class SAGEConv(MessagePassing):

--- a/torch_geometric/nn/conv/sage_conv.py
+++ b/torch_geometric/nn/conv/sage_conv.py
@@ -18,7 +18,8 @@ class SAGEConv(MessagePassing):
 
     Args:
         in_channels (int or tuple): Size of each input sample. A tuple
-            corresponds to the sizes of source and target dimensionalities.
+            corresponds to the sizes of source and target dimensionalities. The
+            size can be -1 for lazy initialization.
         out_channels (int): Size of each output sample.
         normalize (bool, optional): If set to :obj:`True`, output features
             will be :math:`\ell_2`-normalized, *i.e.*,

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -2,10 +2,10 @@ from typing import Optional
 from torch_geometric.typing import Adj, OptTensor
 
 from torch import Tensor
-from torch.nn import Linear
 from torch_sparse import SparseTensor, matmul
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
+from torch_geometric.nn.dense.linear import Linear
 
 
 class SGConv(MessagePassing):

--- a/torch_geometric/nn/conv/sg_conv.py
+++ b/torch_geometric/nn/conv/sg_conv.py
@@ -23,7 +23,8 @@ class SGConv(MessagePassing):
     edge weights via the optional :obj:`edge_weight` tensor.
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         K (int, optional): Number of hops :math:`K`. (default: :obj:`1`)
         cached (bool, optional): If set to :obj:`True`, the layer will cache

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -43,7 +43,8 @@ class SignedConv(MessagePassing):
     the negative node features :math:`\mathbf{X}^{(\textrm{neg})}`.
 
     Args:
-        in_channels (int): Size of each input sample.
+        in_channels (int): Size of each input sample or -1 for lazy
+            initialization.
         out_channels (int): Size of each output sample.
         first_aggr (bool): Denotes which aggregation formula to use.
         bias (bool, optional): If set to :obj:`False`, the layer will not learn

--- a/torch_geometric/nn/conv/signed_conv.py
+++ b/torch_geometric/nn/conv/signed_conv.py
@@ -3,7 +3,7 @@ from torch_geometric.typing import PairTensor, Adj
 
 import torch
 from torch import Tensor
-from torch.nn import Linear
+from torch_geometric.nn.dense.linear import Linear
 from torch_sparse import SparseTensor, matmul
 from torch_geometric.nn.conv import MessagePassing
 

--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -5,8 +5,8 @@ from torch_geometric.typing import PairTensor, Adj, OptTensor
 import torch
 from torch import Tensor
 import torch.nn.functional as F
-from torch.nn import Linear
 from torch_geometric.nn.conv import MessagePassing
+from torch_geometric.nn.dense.linear import Linear
 from torch_geometric.utils import softmax
 
 

--- a/torch_geometric/nn/conv/transformer_conv.py
+++ b/torch_geometric/nn/conv/transformer_conv.py
@@ -29,7 +29,8 @@ class TransformerConv(MessagePassing):
 
     Args:
         in_channels (int or tuple): Size of each input sample. A tuple
-            corresponds to the sizes of source and target dimensionalities.
+            corresponds to the sizes of source and target dimensionalities. The
+            size can be -1 for lazy initialization.
         out_channels (int): Size of each output sample.
         heads (int, optional): Number of multi-head-attentions.
             (default: :obj:`1`)


### PR DESCRIPTION
The PR use lazy linear for almost all GNN operators.
Two GNN operators that use matmul are not included in this PR: `arma_conv`, `rgcn_conv`. Their usecases are a little special and I think we can ignore them for this issue.